### PR TITLE
Add utility scripts and use these scripts in CI

### DIFF
--- a/.github/workflows/verify_conformity.yml
+++ b/.github/workflows/verify_conformity.yml
@@ -10,11 +10,4 @@ jobs:
       - uses: actions/checkout@v2
       - uses: cachix/install-nix-action@v12
       - name: Verifying output files
-        run: |
-          for f in ./genealogos/tests/fixtures/nixtract/success/*.out; do
-            echo "$f"
-            OUT=$(nix run .#cyclonedx --extra-experimental-features 'nix-command flakes' -- validate --input-format json --input-version v1_5 --input-file "$f")
-            echo "$OUT"
-            # Fail if the cyclonedx tool did not output a message containing "successfully"
-            [[ "$OUT" =~ .*successfully.* ]] || exit 1
-          done || exit 1
+        run: nix run .#verify-fixture-files --extra-experimental-features 'nix-command flakes'

--- a/genealogos/src/model.rs
+++ b/genealogos/src/model.rs
@@ -158,7 +158,7 @@ impl From<ModelDependency> for cyclonedx::Dependency {
         let mut depends_on: Vec<String> = model_dependency.depends_on.into_iter().collect();
 
         // For testing, we need deterministic output, so we sort the strings before conversion
-        if cfg!(test) {
+        if cfg!(test) || std::env::var("GENEALOGOS_DETERMINISTIC").is_ok() {
             depends_on.sort_unstable();
         }
 
@@ -187,7 +187,7 @@ impl From<Model> for cyclonedx::CycloneDx {
             .spec_version("1.5")
             .version(1);
 
-        if cfg!(test) {
+        if cfg!(test) || std::env::var("GENEALOGOS_DETERMINISTIC").is_ok() {
             // Deterministic
             cyclonedx.serial_number("urn:uuid:00000000-0000-0000-0000-000000000000");
         } else {

--- a/scripts/update-fixture-files.sh
+++ b/scripts/update-fixture-files.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+if ! builtin type -P "genealogos" &> /dev/null; then
+  echo "Genealogos not found in \$PATH, terminating"
+  exit 1
+fi
+
+for input_file in ./genealogos/tests/fixtures/nixtract/success/*.in; do
+  output_file=${input_file%.in}.out
+  GENEALOGOS_DETERMINISTIC=1 genealogos "$input_file" > "$output_file"
+done

--- a/scripts/update-fixture-files.sh
+++ b/scripts/update-fixture-files.sh
@@ -7,5 +7,6 @@ fi
 
 for input_file in ./genealogos/tests/fixtures/nixtract/success/*.in; do
   output_file=${input_file%.in}.out
+  echo "Updating: $output_file"
   GENEALOGOS_DETERMINISTIC=1 genealogos "$input_file" > "$output_file"
 done

--- a/scripts/verify-fixture-files.sh
+++ b/scripts/verify-fixture-files.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+if ! builtin type -P "cyclonedx" &> /dev/null; then
+  echo "cyclonedx not found in \$PATH, terminating"
+  exit 1
+fi
+
+for f in ./genealogos/tests/fixtures/nixtract/success/*.out; do
+  echo "$f"
+  OUT=$(cyclonedx validate --input-format json --input-version v1_5 --input-file "$f")
+  echo "$OUT"
+  # Fail if the cyclonedx tool did not output a message containing "successfully"
+  [[ "$OUT" =~ .*successfully.* ]] || exit 1
+done


### PR DESCRIPTION
These scripts are also added to the Nix shell, allowing simple updating of the fixture files using `update-fixture-files`. Outside of a Nix shell, these scripts can be executed via `./scripts/update-fixture-files.sh`, but the user must then ensure `genealogos` and `cyclonedx` are in `$PATH`.