### PR TITLE
Document main.rs and allow outputing to specified file

### DIFF
--- a/genealogos-cli/src/main.rs
+++ b/genealogos-cli/src/main.rs
@@ -1,26 +1,40 @@
 use std::error::Error;
-use std::fs::File;
+use std::fs;
 use std::io::{self, BufRead};
-use std::path::PathBuf;
+use std::path;
 
 use clap::Parser;
 
 use genealogos::genealogos;
 
+/// `cli` application for processing data files and generating CycloneDX output
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about)]
 struct Args {
-    file: PathBuf,
+    /// Path to the input nixtract file
+    file: path::PathBuf,
+
+    /// Optional path to the output CycloneDX file (default: stdout)
+    output_file: Option<path::PathBuf>,
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Parse command-line arguments
     let args = Args::parse();
 
-    let file = File::open(args.file)?;
+    let file = fs::File::open(args.file)?;
 
-    let json_out = genealogos(io::BufReader::new(file).lines().flatten())?;
+    // Read lines from the input file and flatten into a single iterator
+    let lines = io::BufReader::new(file).lines().flatten();
 
-    println!("{}", json_out);
+    // Process the input data using `genealogos` and generate CycloneDX JSON
+    let json_out = genealogos(lines)?;
+
+    // Write the CycloneDX JSON to either the specified output file or stdout
+    match args.output_file {
+        Some(path) => fs::write(path.into_os_string(), json_out)?,
+        None => println!("{}", json_out),
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Previously, `genealogos-cli` would always output to stdout, with this change, the user can optionally specify the desired output path.