### PR TITLE
feat: add functions to Backend trait to set options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [#34](https://github.com/tweag/genealogos/pull/34) implements a web-based GUI for Genealogos
 - [#36](https://github.com/tweag/genealogos/pull/36) include nixtract's new narinfo information
 - [#38](https://github.com/tweag/genealogos/pull/38) display nixtract's status information when running
+- [#44](https://github.com/tweag/genealogos/pull/44) adds two functions to the `Backend` trait to set options
 
 ### Changed
 - [#41](https://github.com/tweag/genealogos/pull/41) reworked the Genealogos fronend, paving the way for supporting other bom formats

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ nixtract --target-attribute-path hello /tmp/out && genealogos /tmp/out
 
 For more `nixtract` arguments, see `nixtract --help`.
 
+Setting backend options:
+Any type that implements the `Backend` must have a way to include nar info and only include runtime options.
+Genealogos will forward `--include-narinfo` and `--runtime-only` to the backend.
+```fish
+genealogos --flake-ref nixpkgs --attribute-path hello --include-narinfo --runtime-only
+```
+
 For a full set of options, see:
 ```fish
 genealogos --help

--- a/genealogos-cli/src/main.rs
+++ b/genealogos-cli/src/main.rs
@@ -31,6 +31,14 @@ struct Args {
     #[arg(long, default_value_t)]
     backend: args::BackendArg,
 
+    /// Attempt to include narinfo data in the bom
+    #[arg(long, default_value_t)]
+    include_narinfo: bool,
+
+    /// Attempt to only include runtime dependencies in the bom
+    #[arg(long, default_value_t)]
+    runtime_only: bool,
+
     /// Optional bom specification to output
     #[arg(long, default_value_t)]
     bom: args::BomArg,
@@ -54,7 +62,12 @@ fn main() -> Result<()> {
     };
 
     // Initialize the backend and get access to the status update messages
-    let (backend, handle) = *args.backend.get_backend()?;
+    let (mut backend, handle) = *args.backend.get_backend()?;
+
+    // Set backend options
+    backend.include_narinfo(args.include_narinfo);
+    backend.runtime_only(args.runtime_only);
+
     let messages = handle.messages()?;
 
     // Initialize the frontend (bom)

--- a/genealogos/src/backend/mod.rs
+++ b/genealogos/src/backend/mod.rs
@@ -132,6 +132,36 @@ pub trait Backend {
     /// A `Result` which is `Ok` if the conversion succeeded, and
     ///`crate:error::Error` otherwise.
     fn to_model_from_lines(&self, lines: impl Iterator<Item = impl AsRef<str>>) -> Result<Model>;
+
+    /// Informs the backend to (from now on) attempt to fetch the narinfo for each derivation.
+    ///
+    /// # Arguments
+    ///
+    /// * `fetch` - A boolean indicating whether to fetch the narinfo for each derivation or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use genealogos::backend::Backend;
+    /// let mut backend = genealogos::backend::nixtract_backend::Nixtract::new_without_handle();
+    /// backend.include_narinfo(true);
+    /// ```
+    fn include_narinfo(&mut self, include: bool);
+
+    /// Informs the backend to (from now on) only include runtime dependencies in the model.
+    ///
+    /// # Arguments
+    ///
+    /// * `runtime_only` - A boolean indicating whether to include only runtime dependencies or not.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use genealogos::backend::Backend;
+    /// let mut backend = genealogos::backend::nixtract_backend::Nixtract::new_without_handle();
+    /// backend.runtime_only(true);
+    /// ```
+    fn runtime_only(&mut self, runtime_only: bool);
 }
 
 /// If a backend was created with a `BackendHandle`, it can be queried for status updates.

--- a/genealogos/src/backend/nixtract_backend.rs
+++ b/genealogos/src/backend/nixtract_backend.rs
@@ -89,6 +89,14 @@ impl crate::backend::Backend for Nixtract {
 
         Ok(model)
     }
+
+    fn include_narinfo(&mut self, include: bool) {
+        self.config.include_nar_info = include;
+    }
+
+    fn runtime_only(&mut self, runtime_only: bool) {
+        self.config.runtime_only = runtime_only
+    }
 }
 
 impl super::BackendHandle for NixtractHandle {


### PR DESCRIPTION
# Include Nixtract options
Issue: #37 

## Description
This PR adds functions to the `Backend` trait to set two options. We add it to the trait because we don't know how future implementors of the `Backend` trait will store these options.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
