### PR TITLE
feat: replace Source::Flake with Source::Installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 
 ### Changed
 - [#41](https://github.com/tweag/genealogos/pull/41) reworked the Genealogos fronend, paving the way for supporting other bom formats
+- [#46](https://github.com/tweag/genealogos/pull/46) replaces `Source::Flake` with `Source::Installable` and `--flake-ref, --attribute-path` with `--installable`

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ There are two ways to solve this, either by specifying a specific package `cargo
 ### `genealogos-cli`
 Analyzing a local flake:
 ```fish
-genealogos --flake-ref /path/to/your/local/flake
+genealogos --installable /path/to/your/local/flake
 ```
 
 Analyzing `hello` from nixpkgs:
 ```fish
-genealogos --flake-ref nixpkgs --attribute-path hello
+genealogos --installable nixpkgs#hello
 ```
 
 Using a trace file:
@@ -81,7 +81,7 @@ Setting backend options:
 Any type that implements the `Backend` must have a way to include nar info and only include runtime options.
 Genealogos will forward `--include-narinfo` and `--runtime-only` to the backend.
 ```fish
-genealogos --flake-ref nixpkgs --attribute-path hello --include-narinfo --runtime-only
+genealogos --installable nixpkgs#hello --include-narinfo --runtime-only
 ```
 
 For a full set of options, see:

--- a/README.md
+++ b/README.md
@@ -95,18 +95,19 @@ Genealogos can also run as an API server using the `genealogos-api` binary.
 A blocking endpoint and one based on jobs.
 
 #### Blocking
-Currently, there is only a single blocking endpoint: `/api/analyze?flake_ref=<flake_ref>&attribute_path=<attribute_path>`.
+Currently, there is only a single blocking endpoint: `/api/analyze?installable=<installable>`.
 By default, `genealogos-api` binds itself on `localhost:8000`.
 
 For example, using curl, the api can be invoked like this:
 ```fish
-curl "http://localhost:8000/api/analyze?flake_ref=nixpkgs&attribute_path=hello"
+curl "http://localhost:8000/api/analyze?installable=nixpkgs%23hello"
 ```
+Note that the `#` in `nixpkgs#hello` is URL Encoded.
 
 Additionally an optional `bom_format` query parameter can be provided to specify the bom format to use.
 Example:
 ```fish
-curl "http://localhost:8000/api/analyze?flake_ref=nixpkgs&attribute_path=hello&cyclonedx_version=v1_4"
+curl "http://localhost:8000/api/analyze?installable=nixpkgs%23hello&cyclonedx_version=v1_4"
 ```
 
 <!-- TODO: Add 1.5 support -->
@@ -117,7 +118,7 @@ The jobs based API consists of three endpoints: `/api/jobs/create`, `/api/jobs/s
 
 Creating a job is done in a similar fashion to the blocking api:
 ```fish
-curl "http://localhost:8000/api/jobs/create?flake_ref=nixpkgs&attribute_path=hello"
+curl "http://localhost:8000/api/jobs/create?installable=nixpkgs%23hello"
 ```
 This endpoint also supports the `bom_format` query parameter.
 The response of this API call is a `job_id`, which needs to be passed to further calls to indentify the desired job.

--- a/genealogos-api/src/jobs.rs
+++ b/genealogos-api/src/jobs.rs
@@ -64,7 +64,7 @@ pub async fn create(
     let flake_ref = flake_ref.to_string();
     let attribute_path = attribute_path.to_string();
     tokio::spawn(async move {
-        let source = genealogos::backend::Source::Flake {
+        let source = genealogos::backend::Source::Installable {
             flake_ref,
             attribute_path: Some(attribute_path),
         };

--- a/genealogos-api/src/main.rs
+++ b/genealogos-api/src/main.rs
@@ -120,7 +120,7 @@ mod tests {
 
                 let response = client
                     .get(format!(
-                        "/api/analyze?installable={}#{}",
+                        "/api/analyze?installable={}%23{}",
                         flake_ref, attribute_path
                     ))
                     .dispatch();

--- a/genealogos-api/src/main.rs
+++ b/genealogos-api/src/main.rs
@@ -31,7 +31,7 @@ fn analyze(
     let start_time = std::time::Instant::now();
 
     // Construct the Source from the flake reference and attribute path
-    let source = genealogos::backend::Source::Flake {
+    let source = genealogos::backend::Source::Installable {
         flake_ref: flake_ref.to_string(),
         attribute_path: attribute_path.map(str::to_string),
     };

--- a/genealogos-cli/src/main.rs
+++ b/genealogos-cli/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<()> {
     let source = if let Some(file) = args.file {
         genealogos::backend::Source::TraceFile(file)
     } else {
-        parse_installable(args.installable.expect("installable not present in args"))?
+        Source::parse_installable(args.installable.expect("installable not present in args"))?
     };
 
     // Initialize the backend and get access to the status update messages
@@ -122,25 +122,4 @@ fn main() -> Result<()> {
     }
 
     Ok(())
-}
-
-fn parse_installable(s: impl AsRef<str>) -> Result<Source> {
-    // Split s on the first #-sign
-    let s = s.as_ref();
-    let parts: Vec<&str> = s.splitn(2, '#').collect();
-
-    // If parts has length 1, we know we onlyhave a flake_ref
-    if parts.len() == 1 {
-        Ok(Source::Installable {
-            flake_ref: parts[0].to_string(),
-            attribute_path: None,
-        })
-    } else if parts.len() == 2 {
-        Ok(Source::Installable {
-            flake_ref: parts[0].to_string(),
-            attribute_path: Some(parts[1].to_string()),
-        })
-    } else {
-        anyhow::bail!(format!("Invalid installable source: {}", s))
-    }
 }

--- a/genealogos-frontend/index.html
+++ b/genealogos-frontend/index.html
@@ -55,13 +55,8 @@
                     attribute path. It uses the nixtract to analyze the flake and generate the dependency tree. The BOM
                     is generated in the specified format and can be copied to the clipboard or saved as a file.</p>
                 <div class="mb-3">
-                    <label for="flake-ref">Flake Ref</label>
-                    <input type="text" class="form-control" id="flake-ref" name="flake-ref" placeholder="nixpkgs">
-                </div>
-                <div class="mb-3">
-                    <label for="attribute-path">Attribute Path</label>
-                    <input type="text" class="form-control" id="attribute-path" name="attribute-path"
-                        placeholder="hello">
+                    <label for="installable">Nix Installable</label>
+                    <input type="text" class="form-control" id="installable" name="installable" placeholder="nixpkgs#hello">
                 </div>
                 <div class="mb-3">
                     <label for="bom-format">BOM Format</label>
@@ -120,8 +115,7 @@
         crossorigin="anonymous"></script>
     <script>
         // Global variables for flake ref and attribute path
-        let latestFlakeRef = "";
-        let latestAttributePath = "";
+        let latestInstallable = "";
         let apiAddress = "http://localhost:8000/api"; // Default API address
 
         // Always set the copy and save button to disabled on page load, this fixes a firefox bug
@@ -149,9 +143,8 @@
         }
 
         function generateBOM() {
-            // Get the flake ref and attribute path from the input fields
-            const flakeRef = document.getElementById("flake-ref").value;
-            const attributePath = document.getElementById("attribute-path").value;
+            // Get the installable from the input field
+            const installable = encodeURIComponent(document.getElementById("installable").value);
             const bomFormat = document.getElementById("bom-format").value;
 
             // Create a map where we will store a map from thread id to log message
@@ -172,7 +165,7 @@
             toggleButtons(false);
 
             // Make a request to the API to create a job
-            fetch(`${apiAddress}/jobs/create?flake_ref=${flakeRef}&attribute_path=${attributePath}&bom_format=${bomFormat}`)
+            fetch(`${apiAddress}/jobs/create?installable=${installable}&bom_format=${bomFormat}`)
                 .then(response => response.json())
                 .then(data => {
                     if (data.job_id !== undefined && data.job_id !== null) {
@@ -207,8 +200,7 @@
                                                     toggleButtons(true);
 
                                                     // Set the global variables
-                                                    latestFlakeRef = flakeRef;
-                                                    latestAttributePath = attributePath;
+                                                    latestInstallable = installable;
 
                                                     // Clear the interval
                                                     clearInterval(intervalId);
@@ -267,7 +259,7 @@
             // Create a temporary anchor element
             const anchor = document.createElement("a");
             anchor.href = URL.createObjectURL(blob);
-            anchor.download = `${latestFlakeRef}_${latestAttributePath}.sbom.json`;
+            anchor.download = `${installable}.sbom.json`;
 
             // Programmatically click the anchor element to trigger the download
             anchor.click();

--- a/genealogos/src/backend/mod.rs
+++ b/genealogos/src/backend/mod.rs
@@ -21,8 +21,8 @@ pub mod nixtract_backend;
 ///   the path to the trace file.
 #[derive(Debug)]
 pub enum Source {
-    /// Represents a flake source with a reference and an optional attribute path.
-    Flake {
+    /// Represents a nix installable with a reference and an optional attribute path.
+    Installable {
         flake_ref: String,
         attribute_path: Option<String>,
     },
@@ -59,7 +59,7 @@ pub trait Backend {
     /// the `Model` fails.
     fn to_model_from_source(&self, source: Source) -> Result<Model> {
         match source {
-            Source::Flake {
+            Source::Installable {
                 flake_ref,
                 attribute_path,
             } => self.to_model_from_flake_ref(flake_ref, attribute_path),

--- a/genealogos/src/backend/mod.rs
+++ b/genealogos/src/backend/mod.rs
@@ -37,7 +37,7 @@ impl Source {
         let s = s.as_ref();
         let parts: Vec<&str> = s.splitn(2, '#').collect();
 
-        // If parts has length 1, we know we onlyhave a flake_ref
+        // If parts has length 1, we know we only have a flake_ref
         if parts.len() == 1 {
             Ok(Source::Installable {
                 flake_ref: parts[0].to_string(),

--- a/genealogos/src/error.rs
+++ b/genealogos/src/error.rs
@@ -46,4 +46,8 @@ pub enum Error {
     /// Wraps the `std::fmt::Error`
     #[error("Errors constructing output: {0}")]
     Fmt(#[from] std::fmt::Error),
+
+    /// Parsing the installable to a Source was impossible
+    #[error("Error parsing the installable")]
+    InstallableParsing(String),
 }


### PR DESCRIPTION
## Description
This PR renames `Source::Flake` with `Source::Installable`, additionally it updates the cli to take `--installable nixpkgs#hello` instead of the previous `--flake-ref nixpgks --attribute-path hello`.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
