### PR TITLE
feat: remove the need for --installable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@
 
 ### Changed
 - [#41](https://github.com/tweag/genealogos/pull/41) reworked the Genealogos fronend, paving the way for supporting other bom formats
-- [#46](https://github.com/tweag/genealogos/pull/46) replaces `Source::Flake` with `Source::Installable` and `--flake-ref, --attribute-path` with `--installable`
+- [#46](https://github.com/tweag/genealogos/pull/46) [#47](https://github.com/tweag/genealogos/pull/47) replaces `Source::Flake` with `Source::Installable` and deprecates `--flake-ref, --attribute-path` over `genealogos nixpkgs#hello` and equivalents

--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ There are two ways to solve this, either by specifying a specific package `cargo
 ### `genealogos-cli`
 Analyzing a local flake:
 ```fish
-genealogos --installable /path/to/your/local/flake
+genealogos /path/to/your/local/flake
 ```
 
 Analyzing `hello` from nixpkgs:
 ```fish
-genealogos --installable nixpkgs#hello
+genealogos nixpkgs#hello
 ```
 
 Using a trace file:
 This section assumes you are using the latest `main` version version of [nixtract][nixtract].
 
 ```fish
-nixtract --target-attribute-path hello /tmp/out && genealogos /tmp/out
+nixtract --target-attribute-path hello /tmp/out && genealogos -f /tmp/out
 ```
 
 For more `nixtract` arguments, see `nixtract --help`.
@@ -81,7 +81,7 @@ Setting backend options:
 Any type that implements the `Backend` must have a way to include nar info and only include runtime options.
 Genealogos will forward `--include-narinfo` and `--runtime-only` to the backend.
 ```fish
-genealogos --installable nixpkgs#hello --include-narinfo --runtime-only
+genealogos --include-narinfo --runtime-only nixpkgs#hello
 ```
 
 For a full set of options, see:

--- a/genealogos-cli/src/main.rs
+++ b/genealogos-cli/src/main.rs
@@ -18,7 +18,7 @@ struct Args {
     file: Option<path::PathBuf>,
 
     /// Nix installable (e.g. `nixpkgs#hello`)
-    #[arg(long, required_unless_present = "file")]
+    #[arg(required_unless_present = "file")]
     installable: Option<String>,
 
     /// Optional path to the output CycloneDX file (default: stdout)


### PR DESCRIPTION
# Remove `--installable` flag, use `nixpkgs#hello` etc directly

## Description
Previously, one would have to write `genealogos --installable nixpkgs#hello`, this PR changes that to `genealogos nixpkgs#hello`.

## Motivation
In the original versions of Genealogos, Nixtract wasn't integrated. Instead, it was assumed that one would output the trace and then use Genealogos to read that trace, hence the default being reading from a file.

As we rewrote nixtract in Rust, and then integrated it in Genealogos, this usecase became less desirable. Now, it is mostly assumed that users will hardly ever call nixtract manually (for use with Genealogos).

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
