### PR TITLE
feat: pass through rocket options in nixos-module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - [#36](https://github.com/tweag/genealogos/pull/36) include nixtract's new narinfo information
 - [#38](https://github.com/tweag/genealogos/pull/38) display nixtract's status information when running
 - [#44](https://github.com/tweag/genealogos/pull/44) adds two functions to the `Backend` trait to set options
-- [#48](https://github.com/tweag/genealogos/pull/48) added a NixOS module to our flake
+- [#48](https://github.com/tweag/genealogos/pull/48) [#49](https://github.com/tweag/genealogos/pull/49) added a NixOS module to our flake
 
 ### Changed
 - [#41](https://github.com/tweag/genealogos/pull/41) reworked the Genealogos fronend, paving the way for supporting other bom formats

--- a/nix/configuration.nix
+++ b/nix/configuration.nix
@@ -1,5 +1,8 @@
 { ... }:
 
+let
+  port = 9000;
+in
 {
   virtualisation.vmVariant = {
     virtualisation = {
@@ -8,8 +11,8 @@
       forwardPorts = [
         {
           from = "host";
-          guest.port = 8000;
-          host.port = 8000;
+          guest.port = port;
+          host.port = port;
         }
       ];
     };
@@ -21,6 +24,14 @@
     password = "genealogos";
   };
 
-  services.genealogos.enable = true;
+  services.genealogos = {
+    enable = true;
+    rocketConfig = {
+      release = {
+        port = port;
+        address = "0.0.0.0";
+      };
+    };
+  };
 }
 

--- a/nix/genealogos-module.nix
+++ b/nix/genealogos-module.nix
@@ -5,6 +5,7 @@ with lib;
 
 let
   cfg = config.services.genealogos;
+  rocketConfigFormat = pkgs.formats.toml { };
 in
 {
   options = {
@@ -19,16 +20,43 @@ in
           The genealogos-api package to use.
         '';
       };
+
+      rocketConfig = lib.mkOption {
+        type = rocketConfigFormat.type;
+        default = { };
+        example = lib.literalExpression ''
+          {
+            release = {
+              address = "0.0.0.0";
+              port = "8000";
+              limits = {
+                form = "64 kB";
+                json = "1 MiB";
+              };
+            };
+          }
+        '';
+
+        description = lib.mdDoc ''
+          Configuration file for Genealogos.
+
+          Genealogos-api uses rocket as its http implementation.
+          For all configuration options, see https://rocket.rs/guide/v0.5/configuration/#configuration-parameters
+        '';
+      };
     };
   };
 
   config = mkIf (cfg.enable) {
-    systemd.services.genealogos =
-      {
-        description = "Genealogos sbom generator";
-        wantedBy = [ "multi-user.target" ];
+    systemd.services.genealogos = {
+      description = "Genealogos sbom generator";
+      wantedBy = [ "multi-user.target" ];
 
-        serviceConfig.ExecStart = "${cfg.package}/bin/genealogos-api";
+      serviceConfig.ExecStart = "${cfg.package}/bin/genealogos-api";
+
+      environment = {
+        ROCKET_CONFIG = rocketConfigFormat.generate "Rocket.toml" cfg.rocketConfig;
       };
+    };
   };
 }


### PR DESCRIPTION
Issue: #23 

## Description
This PR allows the users of the NixOS module to set the configuration passed to rocket (which is the http implementation Genealogos uses. The attribute is called `rocketConfig`, in case Genealogos will end up with configuration of its own in the future.

## Motivation
Without adding configuration to Genealogos, this approach is the easiest way to allow end-users to change the listening address, port, etc.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- ~[ ] README.md up-to-date~
