### PR TITLE
Include genealogos frontend in the api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [#38](https://github.com/tweag/genealogos/pull/38) display nixtract's status information when running
 - [#44](https://github.com/tweag/genealogos/pull/44) adds two functions to the `Backend` trait to set options
 - [#48](https://github.com/tweag/genealogos/pull/48) added a NixOS module to our flake
+- [#50](https://github.com/tweag/genealogos/pull/50) included the frontend in rocket behind the `frontend` feature flag
 
 ### Changed
 - [#41](https://github.com/tweag/genealogos/pull/41) reworked the Genealogos fronend, paving the way for supporting other bom formats

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Changing this default can be done using the settings button in the top of the we
 
 The Web UI currently only supports analyzing from a flake ref and attribute path, analyzing from a trace file is not yet supported.
 
+The frontend can be opened by opening the `index.html`file in your favourite webbrowser.
+Alternatively, if the `genealogos-api` was built with the `frontend` feature-flag, the frontend can be accessed at the root of wherever the api is hosted (e.g. `http://localhost:8000/`).
+
 ### NixOS Module
 The flake in this project provides a NixOS Module to host Genealogos.
 Once the module has been added to your NixOS configuration, Genealogos can be enabled with:

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Changing this default can be done using the settings button in the top of the we
 
 The Web UI currently only supports analyzing from a flake ref and attribute path, analyzing from a trace file is not yet supported.
 
-The frontend can be opened by opening the `index.html`file in your favourite webbrowser.
+The frontend can be opened by opening the `index.html`file in your favourite web browser.
 Alternatively, if the `genealogos-api` was built with the `frontend` feature-flag, the frontend can be accessed at the root of wherever the api is hosted (e.g. `http://localhost:8000/`).
 
 ### NixOS Module

--- a/genealogos-api/Cargo.toml
+++ b/genealogos-api/Cargo.toml
@@ -31,6 +31,11 @@ urlencoding.workspace = true
 pretty_assertions.workspace = true
 
 [features]
+default = [ "frontend" ]
+
 # This feature should be enabled when running tests in a Nix environment.
 # It disables all tests that require a working internet connection.
 nix = []
+
+# Enabling this feature makes Genealogos server a gui frontend at IP:PORT/
+frontend = []

--- a/genealogos-api/src/main.rs
+++ b/genealogos-api/src/main.rs
@@ -4,7 +4,7 @@ use genealogos::args::BomArg;
 use genealogos::backend::Backend;
 use genealogos::bom::Bom;
 use rocket::http::Status;
-use rocket::response::status;
+use rocket::response::{content, status};
 use rocket::serde::json::Json;
 use rocket::tokio::sync::Mutex;
 use rocket::Request;
@@ -19,6 +19,14 @@ fn handle_errors(req: &Request) -> status::Custom<String> {
     status::Custom(
         Status::InternalServerError,
         format!("An error occurred: {:?}", req),
+    )
+}
+
+#[rocket::get("/")]
+fn index() -> status::Custom<content::RawHtml<&'static str>> {
+    status::Custom(
+        Status::Ok,
+        content::RawHtml(include_str!("../../genealogos-frontend/index.html")),
     )
 }
 
@@ -63,6 +71,7 @@ fn rocket() -> _ {
                 ));
             })
         }))
+        .mount("/", rocket::routes![index])
         .mount("/api", rocket::routes![analyze])
         .register("/api", rocket::catchers![handle_errors])
         .mount(

--- a/genealogos-api/src/main.rs
+++ b/genealogos-api/src/main.rs
@@ -23,10 +23,20 @@ fn handle_errors(req: &Request) -> status::Custom<String> {
 }
 
 #[rocket::get("/")]
+#[cfg(feature = "frontend")]
 fn index() -> status::Custom<content::RawHtml<&'static str>> {
     status::Custom(
         Status::Ok,
         content::RawHtml(include_str!("../../genealogos-frontend/index.html")),
+    )
+}
+
+#[rocket::get("/")]
+#[cfg(not(feature = "frontend"))]
+fn index() -> status::Custom<content::RawHtml<&'static str>> {
+    status::Custom(
+        Status::Ok,
+        content::RawHtml("<h1>Genealogos is running</h1>"),
     )
 }
 

--- a/genealogos-frontend/index.html
+++ b/genealogos-frontend/index.html
@@ -259,7 +259,7 @@
             // Create a temporary anchor element
             const anchor = document.createElement("a");
             anchor.href = URL.createObjectURL(blob);
-            anchor.download = `${installable}.sbom.json`;
+            anchor.download = `${decodeURIComponent(latestInstallable)}.sbom.json`;
 
             // Programmatically click the anchor element to trigger the download
             anchor.click();

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -8,7 +8,13 @@
 let
   common-crane-args = {
     pname = "genealogos";
-    src = crane-lib.cleanCargoSource (crane-lib.path ../.);
+
+    # We need to also include the frontend .html file for the include_str macro in the api
+    src = pkgs.lib.cleanSourceWith {
+      src = crane-lib.path ../.;
+      filter = path: type: (crane-lib.filterCargoSources path type) || (builtins.match ".*/genealogos-frontend/index.html" path != null);
+    };
+
     strictDeps = true;
 
     cargoArtifacts = cargo-artifacts;


### PR DESCRIPTION
## Description
This enables rocket to serve the index.html page on the root of its binding address.

## Motivation
Previously hosting both the website and the api required the use of some external webserver (like nginx, or simple-http-server). This approach allows the users to forgo that, and just use the builtin rocket server.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
