### PR TITLE
Split off `messages` function into their own trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- We follow the Keep a Changelog standard https://keepachangelog.com/en/1.0.0/ -->
 
 ## [Unreleased]
+### Changed
+- [#55](https://github.com/tweag/genealogos/pull/55) splits of the `messages()` function into its own trait. This resolves many issues caused by a cargo issue.
 
 ## [0.2.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `frontend` feature is enabled by default, so once the api is running open `h
 ## Hacking
 ### Prerequisites
 Development of Genealogos requires Cargo, and some other dependencies.
-We additionally recommend the use of `rust-analyzer`, `cargo-hack`, and `nixtract`.
+We additionally recommend the use of `rust-analyzer` and `nixtract`.
 The easiest way to get these tools it through the Nix development environment.
 ```fish
 nix develop
@@ -68,8 +68,7 @@ nix develop
 Alternatively you can install the dependencies manually, but in that case you are on your own.
 
 ### Building
-Due to [a bug in Cargo](https://github.com/rust-lang/cargo/issues/4463), running `cargo [build, check, clippy, etc]` will fail.
-There are two ways to solve this, either by specifying a specific package `cargo COMMAND -p [genealogos, genealogos-cli, genealogos-api]` or by running `cargo hack COMMAND`.
+Building can be done using Cargo, either by specifying a specific package `cargo COMMAND -p [genealogos, genealogos-cli, genealogos-api]` or by running `cargo COMMAND` for the entire workspace.
 
 ## Usage
 ### `genealogos-cli`

--- a/flake.nix
+++ b/flake.nix
@@ -53,9 +53,6 @@
 
           packages = with pkgs; [
             rust-analyzer
-
-            # https://github.com/rust-lang/cargo/issues/4463
-            cargo-hack
           ];
         };
       });

--- a/genealogos-cli/Cargo.toml
+++ b/genealogos-cli/Cargo.toml
@@ -21,7 +21,7 @@ cyclonedx-bom.workspace = true
 env_logger.workspace = true
 indicatif.workspace = true
 indicatif-log-bridge.workspace = true
-genealogos = { workspace = true, features = [ "backend_handle_messages", "clap" ] }
+genealogos = { workspace = true, features = [ "clap" ] }
 nixtract.workspace = true
 
 [features]

--- a/genealogos-cli/src/main.rs
+++ b/genealogos-cli/src/main.rs
@@ -7,7 +7,7 @@ use std::path;
 use clap::Parser;
 
 use genealogos::args;
-use genealogos::backend::{Backend, BackendHandle};
+use genealogos::backend::{Backend, BackendHandle, BackendHandleMessages};
 
 /// `cli` application for processing data files and generating CycloneDX output
 #[derive(Parser, Debug)]
@@ -57,7 +57,7 @@ fn main() -> Result<()> {
     };
 
     // Initialize the backend and get access to the status update messages
-    let (mut backend, handle) = *args.backend.get_backend()?;
+    let (mut backend, handle) = *args.backend.get_backend_messages()?;
 
     // Set backend options
     backend.include_narinfo(args.include_narinfo);

--- a/genealogos/Cargo.toml
+++ b/genealogos/Cargo.toml
@@ -35,10 +35,6 @@ default = []
 # It disables all tests that require a working internet connection.
 nix = []
 
-# The messages function of the `BanendHandle` trait violates object safety.
-# For those users of the library that don't need to use this trait as an object, and would like access to the `messages` function, this feature should be enabled.
-backend_handle_messages = []
-
 clap = [ "args", "dep:clap" ]
 rocket = [ "args", "dep:rocket" ]
 

--- a/genealogos/src/args.rs
+++ b/genealogos/src/args.rs
@@ -8,7 +8,7 @@ use std::str::FromStr as _;
 #[cfg(feature = "clap")]
 use std::sync::OnceLock;
 
-use crate::backend::{Backend, BackendHandle};
+use crate::backend::{Backend, BackendHandle, BackendHandleMessages};
 use crate::bom::Bom;
 use crate::error::*;
 
@@ -26,7 +26,13 @@ pub enum BackendArg {
 }
 
 impl BackendArg {
+    /// Get a backend and handle that is object safe
     pub fn get_backend(&self) -> Result<Box<(impl Backend, impl BackendHandle)>> {
+        self.get_backend_messages()
+    }
+
+    /// Get a backend and handle that is not object safe and implements the `messages` function
+    pub fn get_backend_messages(&self) -> Result<Box<(impl Backend, impl BackendHandleMessages)>> {
         match self {
             BackendArg::Nixtract => Ok(Box::new(crate::backend::nixtract_backend::Nixtract::new())),
         }

--- a/genealogos/src/backend/mod.rs
+++ b/genealogos/src/backend/mod.rs
@@ -211,10 +211,13 @@ pub trait BackendHandle {
     /// Gets all messages that were produced since the previous call to this function
     fn new_messages(&self) -> Result<Vec<Message>>;
 
-    /// Gets an iterator over all messages
-    #[cfg(feature = "backend_handle_messages")]
-    fn messages(&self) -> Result<impl Iterator<Item = Message>>;
-
     /// Gets an upper bound to the number of different ids to expect in the messages
     fn max_index(&self) -> usize;
+}
+
+/// `BackendHandleMessages` is a trait that defines additional behaviour of a
+/// backend handle that would otherwise make the `BackendHandle` trait unsafe.
+pub trait BackendHandleMessages: BackendHandle {
+    /// Gets an iterator over all messages
+    fn messages(&self) -> Result<impl Iterator<Item = Message>>;
 }

--- a/genealogos/src/backend/nixtract_backend.rs
+++ b/genealogos/src/backend/nixtract_backend.rs
@@ -114,16 +114,17 @@ impl super::BackendHandle for NixtractHandle {
         Ok(messages)
     }
 
-    #[cfg(feature = "backend_handle_messages")]
+    fn max_index(&self) -> usize {
+        rayon::current_num_threads()
+    }
+}
+
+impl super::BackendHandleMessages for NixtractHandle {
     fn messages(&self) -> crate::Result<impl Iterator<Item = super::Message>> {
         Ok(self.receiver.iter().map(|m| super::Message {
             index: m.id,
             content: m.to_string(),
         }))
-    }
-
-    fn max_index(&self) -> usize {
-        rayon::current_num_threads()
     }
 }
 

--- a/nix/crane.nix
+++ b/nix/crane.nix
@@ -28,8 +28,8 @@ let
   cargo-artifacts = crane-lib.buildDepsOnly common-crane-args;
 
   workspace = (common-crane-args // {
-    cargoBuildCommand = "${pkgs.cargo-hack}/bin/cargo-hack hack build --profile release";
-    cargoTestCommand = "${pkgs.cargo-hack}/bin/cargo-hack hack test --profile release";
+    cargoBuildCommand = "cargo build --profile release";
+    cargoTestCommand = "cargo test --profile release";
   });
 
   # Crane buildPackage arguments for every crate


### PR DESCRIPTION
<!-- Please refer to an issue, or remove this line if the PR is unrelated to an issue -->
Issue: #53 

## Description
This PR splits of the `messages()` function of the `BackendHandle` trait into its own `BackendHandleMessages` trait. This removes the previously used feature, and ensures the `BackendHandle` trait is always object safe.

## Motivation
Previously, a cargo bug would union all features of a crate in the dependency tree. This means that `cargo COMMAND` would fail because `genealogos-api` required the `BackendHandle` to be object safe, and `genealogos-cli` required the `BackendHandle` trait to implement the `messages()` function.

As a result, `cargo dist`, `cargo build`, `rust-analyzer`, and many other commands would fail. This PR resolves that issue.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
