### PR TITLE
feat: add a garbage collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## [Unreleased]
 
+### Added
+- [#56](https://github.com/tweag/genealogos/pull/56) adds a garbage collector to the jobs api, to prevent stale jobs from taking up unnecessary memory
+
 ## [0.3.0](https://github.com/tweag/genealogos/compare/v0.2.0...v0.3.0)
 ### Changed
 - [#55](https://github.com/tweag/genealogos/pull/55) splits of the `messages()` function into its own trait. This resolves many issues caused by a cargo issue.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,17 @@ Finally, getting the result is done with the `result` endpoint:
 curl "http://localhost:8000/api/jobs/result/0"
 ```
 
+#### Configuration
+The `genealogos-api` can be configured through [Rocket](https://rocket.rs)'s configuration mechanism.
+It uses the [default providers](https://rocket.rs/guide/v0.5/configuration/#default-provider) defined by Rocket.
+The [default options](https://rocket.rs/guide/v0.5/configuration/#overview) contain all things related to the webserver itself.
+In addition to those default configuration options, Genealogos extends Rockets' configuration with two additional keys:
+
+| key              | kind               | description                                                        | debug/release default |
+|------------------|--------------------|--------------------------------------------------------------------|-----------------------|
+| `gc_interval`    | `u64` (in seconds) | The interval between two invocations of the garbage collector      | `10`                  |
+| `gc_stale_after` | `u64` (in seconds) | How long after being touched last a job should be considered stale | `60 * 10`             |
+
 ### `genealogos-frontend`
 Genealogos ships with a pure html/javascript web frontend.
 By default, this frontend uses `127.0.0.1` to connect to the `genealogos-api`.

--- a/genealogos-api/Cargo.toml
+++ b/genealogos-api/Cargo.toml
@@ -15,11 +15,12 @@ path = "src/main.rs"
 
 [dependencies]
 chrono.workspace = true
-rocket.workspace = true
 genealogos = { workspace = true, features = [ "rocket" ] }
-serde_json.workspace = true
-serde.workspace = true
+log.workspace = true
 nixtract.workspace = true
+rocket.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/genealogos-api/src/config.rs
+++ b/genealogos-api/src/config.rs
@@ -1,0 +1,17 @@
+use super::job_map::{GCInterval, GCStaleAfter};
+
+#[derive(rocket::serde::Deserialize, Debug)]
+#[serde(crate = "rocket::serde")]
+pub struct Config {
+    #[serde(flatten)]
+    pub gc: GCConfig,
+}
+
+#[derive(rocket::serde::Deserialize, Debug)]
+#[serde(crate = "rocket::serde")]
+pub struct GCConfig {
+    #[serde(default, rename = "gc_interval")]
+    pub interval: GCInterval,
+    #[serde(default, rename = "gc_stale_after")]
+    pub stale_after: GCStaleAfter,
+}

--- a/genealogos-api/src/jobs.rs
+++ b/genealogos-api/src/jobs.rs
@@ -9,29 +9,9 @@ use rocket::tokio;
 
 use crate::messages::{self, Result, StatusEnum, StatusResponse};
 
-pub type JobId = u16;
+pub mod job_map;
 
-/// This JobMap holds the status of all jobs that are currently running
-pub type JobMap = Arc<rocket::tokio::sync::Mutex<std::collections::HashMap<JobId, JobStatus>>>;
-
-pub enum JobStatus {
-    Stopped,
-    /// The job is still running, the receiver is used receive status messages from worker threads
-    Running(Box<dyn genealogos::backend::BackendHandle + Send>),
-    Done(String, time::Duration),
-    Error(String),
-}
-
-impl ToString for JobStatus {
-    fn to_string(&self) -> String {
-        match self {
-            JobStatus::Running(_) => "running".to_string(),
-            JobStatus::Done(_, _) => "done".to_string(),
-            JobStatus::Stopped => "stopped".to_string(),
-            JobStatus::Error(e) => e.to_owned(),
-        }
-    }
-}
+use job_map::{JobId, JobMap, JobStatus};
 
 #[rocket::get("/create?<installable>&<bom_format>")]
 pub async fn create(

--- a/genealogos-api/src/jobs.rs
+++ b/genealogos-api/src/jobs.rs
@@ -90,9 +90,7 @@ pub async fn status(
     job_id: JobId,
     job_map: &rocket::State<JobMap>,
 ) -> Result<messages::StatusResponse> {
-    let mut locked_map = job_map
-        .try_lock()
-        .map_err(|e| messages::ErrResponse::with_job_id(job_id, e))?;
+    let mut locked_map = job_map.lock().await;
 
     let status = locked_map.get(&job_id).unwrap_or(&JobStatus::Stopped);
 

--- a/genealogos-api/src/jobs/job_map.rs
+++ b/genealogos-api/src/jobs/job_map.rs
@@ -1,0 +1,101 @@
+use rocket::tokio::time;
+
+pub type JobMap = std::sync::Arc<rocket::tokio::sync::Mutex<JobHashMap>>;
+
+/// This JobMap holds the status of all jobs that are currently running
+pub struct JobHashMap(std::collections::HashMap<JobId, JobMapEntry>);
+
+/// A single entry in the job map, contains all data related to the job and some
+/// metadata required for the garbage collector.
+pub struct JobMapEntry {
+    /// Stores the last time this job was accesed. Any job that is not accessed
+    /// for a certain amount of time is considered stale and will be removed.
+    last_updated: time::Instant,
+    /// The status of the job
+    status: JobStatus,
+}
+
+pub type JobId = u16;
+
+/// The status of a single job
+pub enum JobStatus {
+    /// The job has been stopped and is not running anymore, or it has not been started yet
+    Stopped,
+    /// The job is still running, the receiver is used receive status messages from worker threads
+    Running(Box<dyn genealogos::backend::BackendHandle + Send>),
+    /// The job has finished, the string contains the output of the job
+    /// and the duration contains how long it took to finish
+    Done(String, time::Duration),
+    /// The job has thrown an error, the string contains the error message
+    Error(String),
+}
+
+impl ToString for JobStatus {
+    fn to_string(&self) -> String {
+        match self {
+            JobStatus::Running(_) => "running".to_string(),
+            JobStatus::Done(_, _) => "done".to_string(),
+            JobStatus::Stopped => "stopped".to_string(),
+            JobStatus::Error(e) => e.to_owned(),
+        }
+    }
+}
+
+impl JobMapEntry {
+    pub fn new(status: JobStatus) -> Self {
+        Self {
+            last_updated: time::Instant::now(),
+            status,
+        }
+    }
+}
+
+impl JobHashMap {
+    pub fn insert(&mut self, job_id: JobId, job_status: JobStatus) {
+        self.0.insert(job_id, JobMapEntry::new(job_status));
+    }
+
+    pub fn get(&mut self, job_id: &JobId) -> Option<&JobStatus> {
+        self.0.get(job_id).map(|entry| &entry.status)
+    }
+
+    pub fn remove(&mut self, job_id: &JobId) -> Option<JobStatus> {
+        self.0.remove(job_id).map(|entry| entry.status)
+    }
+
+    pub(crate) fn new() -> Self {
+        Self(std::collections::HashMap::new())
+    }
+}
+
+/// The garbage collector will check for any stale jobs in the `JobMap` and remove them
+/// after a certain amount of time. The interval is how often the garbage collector
+/// will run, and the remove_after is when a job is considered stale.
+/// The garbage collector will run in a loop forever.
+/// This function will block the thread it is running in.
+///
+/// # Arguments
+/// * `job_map` - A reference to the `JobMap` that contains all the jobs
+/// * `interval` - How often the garbage collector will run
+/// * `remove_after` - How long after a job is considered stale
+pub async fn garbage_collector(
+    job_map: JobMap,
+    interval: time::Duration,
+    remove_after: time::Duration,
+) {
+    let mut interval = time::interval(interval);
+
+    log::info!("Started the garbage collector");
+
+    loop {
+        log::info!("Collecting garbage");
+        interval.tick().await;
+
+        for (job_id, job_entry) in job_map.lock().await.0.iter_mut() {
+            if job_entry.last_updated.elapsed() > remove_after {
+                log::info!("Removing a stale job");
+                job_map.lock().await.remove(job_id);
+            }
+        }
+    }
+}

--- a/nix/genealogos-module.nix
+++ b/nix/genealogos-module.nix
@@ -40,8 +40,11 @@ in
         description = lib.mdDoc ''
           Configuration file for Genealogos.
 
-          Genealogos-api uses rocket as its http implementation.
-          For all configuration options, see https://rocket.rs/guide/v0.5/configuration/#configuration-parameters
+          Genealogos-api uses Rocket as its webserver implementation.
+          For all rocket configuration options, see https://rocket.rs/guide/v0.5/configuration/#configuration-parameters
+
+          Genealogos further defines some custom options.
+          See the projects [README](https://github.com/tweag/genealogos/blob/master/README.md) for more information.
         '';
       };
     };


### PR DESCRIPTION
## Description
When a job is created and completed, but the result is not collected, the job would previously remain in the job map. With these jobs not being collected, they would remain in the job map forever. The garbage collector removes them after they have been stale for a while.

## Motivation
Prevent a memory blow up when running the api for extended periods of time.

## Checklist
Checklist before merging:
- [x] CHANGELOG.md updated
- [x] README.md up-to-date
