### PR TITLE
chore: make NixOS module compatible with nixpkgs

### DIFF
--- a/nix/genealogos-module.nix
+++ b/nix/genealogos-module.nix
@@ -10,13 +10,13 @@ in
 {
   options = {
     services.genealogos = {
-      enable = mkEnableOption
-        (mdDoc "Genealogos, a Nix sbom generator");
+      enable = mkEnableOption "Genealogos, a Nix sbom generator";
 
       package = mkOption {
         type = types.package;
         default = genealogos-api;
-        description = mdDoc ''
+        defaultText = literalExpression "pkgs.genealogos-api";
+        description = ''
           The genealogos-api package to use.
         '';
       };
@@ -37,7 +37,7 @@ in
           }
         '';
 
-        description = lib.mdDoc ''
+        description = ''
           Configuration file for Genealogos.
 
           Genealogos-api uses Rocket as its webserver implementation.


### PR DESCRIPTION
## Description
Updates the NixOS module to abide by nixpkgs' rules. Including removing our use of `mdDoc`.

## Motivation
Keeping our nixosModule and the one in nixpkgs synchronized makes development easier.
